### PR TITLE
adds support for multiple worker classes, activeJob wrapped classes

### DIFF
--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -19,9 +19,17 @@ class HistoryWorker
   include Sidekiq::Worker
 end
 
-def middlewared
+class OtherHistoryWorker
+  include Sidekiq::Worker
+end
+
+class ActiveJobWorker
+  include Sidekiq::Worker
+end
+
+def middlewared(worker_class = HistoryWorker, msg = {})
   middleware = Sidekiq::History::Middleware.new
-  middleware.call HistoryWorker.new, {}, 'default' do
+  middleware.call worker_class.new, msg, 'default' do
     yield
   end
 end


### PR DESCRIPTION
When I saw that my workers were all showing up in the 'Workers Table' as 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper', I set out to see how Sidekiq supported wrapped job classes. Realizing that they instantiate a Sidekiq::Job using the payload from Redis, that feature was easy to implement.

However, once done, I realized that there's a bug in the code that saves the wrong hash for the job history to redis. Using more than one job class, the worker process would crash when trying to write the 2nd job's status to the 'sidekiq:history:#{date}' hash. 

I updated the middleware_test suite to check these new cases, but please give me any feedback if you'd like to see these changes implemented differently. 

Cheers!

p.s. thank you for writing the best history plugin for Sidekiq, ever. 